### PR TITLE
Apptekst innholdstype

### DIFF
--- a/desk-structure.ts
+++ b/desk-structure.ts
@@ -14,9 +14,10 @@ import { seksjon } from "./schemas/soknad/seksjon";
 import { faktum } from "./schemas/soknad/faktum";
 import { svaralternativ } from "./schemas/soknad/svaralternativ";
 import { landgruppe } from "./schemas/soknad/landgruppe";
+import { apptekst } from "./schemas/soknad/apptekst";
 
 const oldSchemaNames = [deltTekst.name, faktaSide.name, notifikasjon.name, situasjon.name];
-const soknadSchemaNames = [seksjon.name, faktum.name, svaralternativ.name, landgruppe.name];
+const soknadSchemaNames = [seksjon.name, faktum.name, svaralternativ.name, landgruppe.name, apptekst.name];
 const isSoknadSchema = (listItem) => soknadSchemaNames.includes(listItem.id);
 const internationalizedSoknadTypeItems =
   InternationalizationStructure.getFilteredDocumentTypeListItems().filter(isSoknadSchema);

--- a/schemas/schema.ts
+++ b/schemas/schema.ts
@@ -9,6 +9,7 @@ import { seksjon } from "./soknad/seksjon";
 import { faktum } from "./soknad/faktum";
 import { svaralternativ } from "./soknad/svaralternativ";
 import { landgruppe } from "./soknad/landgruppe";
+import { apptekst } from "./soknad/apptekst";
 
 export default createSchema({
   name: "dagpenger-info",
@@ -23,6 +24,7 @@ export default createSchema({
     seksjon,
     faktum,
     svaralternativ,
-    landgruppe
+    landgruppe,
+    apptekst,
   ]),
 });

--- a/schemas/soknad/apptekst.ts
+++ b/schemas/soknad/apptekst.ts
@@ -1,0 +1,19 @@
+import { textIdField, valueTextField } from "./common-fields";
+
+export const apptekst = {
+  type: "document",
+  name: "apptekst",
+  title: "Apptekst",
+  i18n: true,
+  initialValue: {
+    // eslint-disable-next-line camelcase
+    __i18n_lang: "nb",
+  },
+  fields: [textIdField, valueTextField],
+  preview: {
+    select: {
+      title: textIdField.name,
+      subtitle: valueTextField.name,
+    },
+  },
+};

--- a/schemas/soknad/common-fields.ts
+++ b/schemas/soknad/common-fields.ts
@@ -95,3 +95,9 @@ export const alertTextField = {
     },
   ],
 };
+
+export const valueTextField = {
+  type: "string",
+  name: "valueText",
+  title: "Verdi",
+};


### PR DESCRIPTION
Lager en egen innholdstype for tekster som er enkle tekster, eksempelvis knapper, tekst på spinner for lasting ++. 

Tar gjerne også innspill på navnet til komponenten. Jeg kalte det apptekst fordi det er et begrep jeg er vant med fra tidligere. Men det kan gjerne hete noe annet. 😃 

Slik ser et innhold ut med denne koden:
![image](https://user-images.githubusercontent.com/3233286/176206642-e613b1e4-f624-4e30-9617-f6a91dc10e61.png)
