### PR TITLE
DAG-352: Forbedre hvordan vi håndtere faktum alert med tomme tekst

### DIFF
--- a/schemas/soknad/common-fields.ts
+++ b/schemas/soknad/common-fields.ts
@@ -66,8 +66,6 @@ export const alertTextField = {
   type: "object",
   name: "alertText",
   title: "Varseltekst",
-  //@ts-ignore;
-  hidden: ({ document }): boolean | undefined => !document?.activateAlertText,
   fields: [
     {
       type: "string",
@@ -94,6 +92,11 @@ export const alertTextField = {
           type: "block",
         },
       ],
+    },
+    {
+      name: "active",
+      title: "Aktiver varseltekst",
+      type: "boolean",
     },
   ],
 };

--- a/schemas/soknad/common-fields.ts
+++ b/schemas/soknad/common-fields.ts
@@ -68,6 +68,11 @@ export const alertTextField = {
   title: "Varseltekst",
   fields: [
     {
+      name: "active",
+      title: "Aktiver varseltekst",
+      type: "boolean",
+    },
+    {
       type: "string",
       name: "type",
       title: "Type",
@@ -92,11 +97,6 @@ export const alertTextField = {
           type: "block",
         },
       ],
-    },
-    {
-      name: "active",
-      title: "Aktiver varseltekst",
-      type: "boolean",
     },
   ],
 };

--- a/schemas/soknad/svaralternativ.ts
+++ b/schemas/soknad/svaralternativ.ts
@@ -9,16 +9,7 @@ export const svaralternativ = {
     // eslint-disable-next-line camelcase
     __i18n_lang: "nb",
   },
-  fields: [
-    textIdField,
-    answerTextField,
-    {
-      name: "activateAlertText",
-      title: "Aktiver varseltekst",
-      type: "boolean",
-    },
-    alertTextField,
-  ],
+  fields: [textIdField, answerTextField, alertTextField],
   preview: {
     select: {
       title: answerTextField.name,


### PR DESCRIPTION
Forrige forsøkt har jeg lagt til en slags skjule eller vise alert teksten, her har jeg lagt til en boolean i schema "active". Lettere og bedre løsning.