### PR TITLE
DAG-368: Fjerner ubrukte felter på dokumentkrav og alertText-feltet

### DIFF
--- a/schemas/soknad/common-fields.ts
+++ b/schemas/soknad/common-fields.ts
@@ -91,7 +91,6 @@ export const alertTextField = {
       },
     },
     { type: "string", name: "title", title: "Tittel" },
-    { type: "string", name: "test", title: "Tittel" },
     {
       type: "array",
       name: "body",

--- a/schemas/soknad/dokumentkrav.ts
+++ b/schemas/soknad/dokumentkrav.ts
@@ -1,4 +1,4 @@
-import { descriptionTextField, helpTextField, questionTextField, textIdField, unitField } from "./common-fields";
+import { descriptionTextField, helpTextField, questionTextField, textIdField } from "./common-fields";
 
 export const dokumentkrav = {
   type: "document",
@@ -9,7 +9,7 @@ export const dokumentkrav = {
     // eslint-disable-next-line camelcase
     __i18n_lang: "nb",
   },
-  fields: [textIdField, questionTextField, descriptionTextField, helpTextField, unitField],
+  fields: [textIdField, questionTextField, descriptionTextField, helpTextField],
   preview: {
     select: {
       title: questionTextField.name,


### PR DESCRIPTION
Småfiks på typen til dokumentkrav + fjernet dobbelt tittelfelt på alertText.