### PR TITLE
Ankerlenke slug for innholdsseksjoner på Produktsside for dagpenger

### DIFF
--- a/desk-structure.ts
+++ b/desk-structure.ts
@@ -19,6 +19,7 @@ import { infopage } from "./schemas/soknad/infopage";
 import oppsett from "./schemas/infosider/oppsett/oppsett";
 import FaktasideSEOPreview from "./previews/FaktasideSEOPreview";
 import FaktasidePreview from "./previews/FaktasidePreview";
+import { ProduktsidePreview } from "./previews/ProduktsidePreview/ProduktsidePreview";
 import { innholdsseksjon, siteSettings } from "./schemas/produktside/schema";
 import { UnserializedListItem } from "@sanity/structure/src/ListItem";
 import { dokumentkrav } from "./schemas/soknad/dokumentkrav";
@@ -48,10 +49,6 @@ const isSoknadSchema = (listItem: UnserializedListItem) => soknadSchemaNames.inc
 const internationalizedSoknadTypeItems =
   InternationalizationStructure.getFilteredDocumentTypeListItems().filter(isSoknadSchema);
 
-const isProduktsideSchema = (listItem: UnserializedListItem) => produktsideSchemaNames.includes(listItem.id);
-const internationalizedProduktsideTypeItems =
-  InternationalizationStructure.getFilteredDocumentTypeListItems().filter(isProduktsideSchema);
-
 export default () =>
   S.list()
     .title("Innhold")
@@ -72,7 +69,39 @@ export default () =>
 
       S.listItem()
         .title("Produktside beta")
-        .child(S.list().title("Produktside beta").items(internationalizedProduktsideTypeItems)),
+        .child(
+          S.list()
+            .title("Produktside beta")
+            .items([
+              S.listItem()
+                .title("Oppsett")
+                .icon(MdSettings)
+                .child(
+                  S.editor()
+                    .schemaType(siteSettings.name)
+                    .documentId(siteSettings.name)
+                    .views([S.view.form(), S.view.component(ProduktsidePreview).title("Preview")])
+
+                  // eslint-disable-next-line no-warning-comments
+                  // TODO: Finn ut hvordan vi kan sette språk for dette elementet uten å måtte rendre en liste
+                ),
+
+              S.listItem()
+                .title("Innholdsseksjoner")
+                .child(
+                  S.documentList()
+                    .title("Innholdsseksjon")
+                    .schemaType(innholdsseksjon.name)
+                    .filter('_type == "innholdsseksjon" && __i18n_lang == $baseLanguage')
+                    .params({ baseLanguage: `nb` })
+                    .child(
+                      S.editor()
+                        .schemaType(innholdsseksjon.name)
+                        .views([S.view.form(), S.view.component(ProduktsidePreview).title("Preview")])
+                    )
+                ),
+            ])
+        ),
 
       S.listItem()
         .title("Gamle infosider")

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
         "react-dom": "^17.0.2",
         "react-icons": "^4.4.0",
         "react-is": "^18.2.0",
+        "sanity-plugin-prefixed-slug": "^1.0.1",
         "styled-components": "^5.3.5",
         "swr": "^1.3.0",
         "typescript": "^4.7.4"
@@ -19872,6 +19873,29 @@
         "node": ">=10"
       }
     },
+    "node_modules/sanity-plugin-prefixed-slug": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/sanity-plugin-prefixed-slug/-/sanity-plugin-prefixed-slug-1.0.1.tgz",
+      "integrity": "sha512-u3RdktLyJd5NoIaPd1IBqfH33a/W+s8WvpuQ4QlQQo5MHxnQTwBkeA2tM+PadWG0idAeq08BqqbaZrhIuTk0Fg==",
+      "dependencies": {
+        "@sanity/base": ">= 2.5.0",
+        "@sanity/ui": ">= 0.33.9",
+        "@sanity/util": ">= 2.5.0",
+        "speakingurl": "^14.0.1"
+      },
+      "peerDependencies": {
+        "react": "^17.0.0",
+        "styled-components": ">= 5.0.0"
+      }
+    },
+    "node_modules/sanity-plugin-prefixed-slug/node_modules/speakingurl": {
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/speakingurl/-/speakingurl-14.0.1.tgz",
+      "integrity": "sha512-1POYv7uv2gXoyGFpBCmpDVSNV74IfsWlDW216UPjbWufNf+bSU6GdbDsxdcxtfwb4xlI3yxzOTKClUosxARYrQ==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/sax": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
@@ -39003,6 +39027,24 @@
       "integrity": "sha512-J5YeuM/S7rLTp51iqUunwzz7Rf68K/jCDGKtNCj6Wzcfgf9CH+0GtPlvf2DFsg0QQhYYZ72FOVn6skmoLjMCdw==",
       "requires": {
         "diff-match-patch": "^1.0.5"
+      }
+    },
+    "sanity-plugin-prefixed-slug": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/sanity-plugin-prefixed-slug/-/sanity-plugin-prefixed-slug-1.0.1.tgz",
+      "integrity": "sha512-u3RdktLyJd5NoIaPd1IBqfH33a/W+s8WvpuQ4QlQQo5MHxnQTwBkeA2tM+PadWG0idAeq08BqqbaZrhIuTk0Fg==",
+      "requires": {
+        "@sanity/base": ">= 2.5.0",
+        "@sanity/ui": ">= 0.33.9",
+        "@sanity/util": ">= 2.5.0",
+        "speakingurl": "^14.0.1"
+      },
+      "dependencies": {
+        "speakingurl": {
+          "version": "14.0.1",
+          "resolved": "https://registry.npmjs.org/speakingurl/-/speakingurl-14.0.1.tgz",
+          "integrity": "sha512-1POYv7uv2gXoyGFpBCmpDVSNV74IfsWlDW216UPjbWufNf+bSU6GdbDsxdcxtfwb4xlI3yxzOTKClUosxARYrQ=="
+        }
       }
     },
     "sax": {

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "react-dom": "^17.0.2",
     "react-icons": "^4.4.0",
     "react-is": "^18.2.0",
+    "sanity-plugin-prefixed-slug": "^1.0.1",
     "styled-components": "^5.3.5",
     "swr": "^1.3.0",
     "typescript": "^4.7.4"

--- a/previews/ProduktsidePreview/ProduktsidePreview.module.css
+++ b/previews/ProduktsidePreview/ProduktsidePreview.module.css
@@ -1,0 +1,18 @@
+.container {
+  background-color: white;
+  height: calc(100% - 2rem);
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+}
+
+.container > a {
+  color: #0067c5;
+}
+
+.container > iframe {
+  margin-top: 0.5rem;
+  width: 100%;
+  box-shadow: 0 0 1rem #888;
+  flex-grow: 1;
+}

--- a/previews/ProduktsidePreview/ProduktsidePreview.tsx
+++ b/previews/ProduktsidePreview/ProduktsidePreview.tsx
@@ -1,0 +1,21 @@
+import React from "react";
+import { getDataset } from "../../utils/getDataset";
+// @ts-ignore
+import styles from "./ProduktsidePreview.module.css";
+
+export function ProduktsidePreview() {
+  const dataset = getDataset();
+  const path = `?preview=true&dataset=${dataset}`;
+
+  const url =
+    dataset === "production" ? `https://www.nav.no/dagpenger${path}` : `https://arbeid.dev.nav.no/dagpenger${path}`;
+
+  return (
+    <div className={styles.container}>
+      <a href={url} target="_blank" rel="noreferrer">
+        Åpne i egen fane
+      </a>
+      <iframe src={url} title={"Preview Produktside"} />
+    </div>
+  );
+}

--- a/schemas/produktside/innholdsseksjon/innholdsseksjon.ts
+++ b/schemas/produktside/innholdsseksjon/innholdsseksjon.ts
@@ -5,6 +5,10 @@ export const innholdsseksjon = {
   type: "document",
   title: "Innholdsseksjon",
   i18n: true,
+  initialValue: {
+    // eslint-disable-next-line camelcase
+    __i18n_lang: "nb",
+  },
   // eslint-disable-next-line camelcase
   //__experimental_actions: ["update", "publish"], // Har du laget et nytt datasett må du midlertidig fjerne denne for å kunne lage et nytt oppsett-dokument
   icon: MdWeb,

--- a/schemas/produktside/innholdsseksjon/innholdsseksjon.ts
+++ b/schemas/produktside/innholdsseksjon/innholdsseksjon.ts
@@ -26,11 +26,12 @@ export const innholdsseksjon = {
       title: "Ankerlenke for innholdsseksjon",
       description:
         "Velg en god ankerlenke. Hvis den må endres i ettertid vil dette knekke lenker som går til denne siden.",
-      validation: (Rule) => Rule.required().max(96).error("Ankerlenke er påkrevd med maks 96 tegn"),
+      validation: (Rule) => Rule.required().error("Ankerlenke er påkrevd med maks 96 tegn"),
       inputComponent: SlugInput,
       options: {
         source: "title",
         urlPrefix: "nav.no/dagpenger#",
+        maxLength: 96,
       },
     },
     {

--- a/schemas/produktside/innholdsseksjon/innholdsseksjon.ts
+++ b/schemas/produktside/innholdsseksjon/innholdsseksjon.ts
@@ -1,3 +1,4 @@
+import SlugInput from "sanity-plugin-prefixed-slug";
 import { MdWeb } from "react-icons/md";
 
 export const innholdsseksjon = {
@@ -17,6 +18,20 @@ export const innholdsseksjon = {
       name: "title",
       type: "string",
       title: "Tittel",
+      validation: (Rule) => Rule.required().error("Tittel er påkrevd."),
+    },
+    {
+      name: "slug",
+      type: "slug",
+      title: "Ankerlenke for innholdsseksjon",
+      description:
+        "Velg en god ankerlenke. Hvis den må endres i ettertid vil dette knekke lenker som går til denne siden.",
+      validation: (Rule) => Rule.required().max(96).error("Ankerlenke er påkrevd med maks 96 tegn"),
+      inputComponent: SlugInput,
+      options: {
+        source: "title",
+        urlPrefix: "nav.no/dagpenger#",
+      },
     },
     {
       name: "innhold",

--- a/schemas/produktside/innholdsseksjon/innholdsseksjonReference.ts
+++ b/schemas/produktside/innholdsseksjon/innholdsseksjonReference.ts
@@ -23,9 +23,10 @@ export const innholdsseksjonReference = {
             .map(({ innholdsseksjon }) => innholdsseksjon?._ref);
 
           return {
-            filter: '!(_id in path("drafts.**")) && !(_id in $usedReferences)',
+            filter: '!(_id in path("drafts.**")) && !(_id in $usedReferences) && (__i18n_lang == $baseLanguage)',
             params: {
               usedReferences,
+              baseLanguage: document?.__i18n_lang,
             },
           };
         },

--- a/schemas/produktside/siteSettings.ts
+++ b/schemas/produktside/siteSettings.ts
@@ -3,6 +3,10 @@ export const siteSettings = {
   title: "Site Settings",
   type: "document",
   i18n: true,
+  initialValue: {
+    // eslint-disable-next-line camelcase
+    __i18n_lang: "nb",
+  },
   // eslint-disable-next-line camelcase
   __experimental_actions: ["update", "publish"], // Har du laget et nytt datasett må du midlertidig fjerne denne for å kunne lage et nytt oppsett-dokument
   fields: [

--- a/yarn.lock
+++ b/yarn.lock
@@ -1345,7 +1345,7 @@
   "resolved" "https://registry.npmjs.org/@sanity/asset-utils/-/asset-utils-1.2.3.tgz"
   "version" "1.2.3"
 
-"@sanity/base@^2.0", "@sanity/base@^2.0.0", "@sanity/base@^2.21.0", "@sanity/base@^2.30.5", "@sanity/base@2.30.5":
+"@sanity/base@^2.0", "@sanity/base@^2.0.0", "@sanity/base@^2.21.0", "@sanity/base@^2.30.5", "@sanity/base@>= 2.5.0", "@sanity/base@2.30.5":
   "integrity" "sha512-BFnDURVV29IcODUaj0ZJ4X1GuYxEO4UbSWMq6x0Ui5oLg+Yqrk2wIR4y4LSjhQq9cA5gKPNGOqSgAQC1yA9Rtg=="
   "resolved" "https://registry.npmjs.org/@sanity/base/-/base-2.30.5.tgz"
   "version" "2.30.5"
@@ -1981,7 +1981,7 @@
     "@types/react" "^17.0.42"
     "rxjs" "^6.5.3"
 
-"@sanity/ui@^0.37.0", "@sanity/ui@^0.37.9":
+"@sanity/ui@^0.37.0", "@sanity/ui@^0.37.9", "@sanity/ui@>= 0.33.9":
   "integrity" "sha512-Gyj7tC/0jKLYwJY/s1I7pU6fhzgP/jB7u2Xi20ZxLukWUioS95ccZ1bRcOBNk4aBqmroRs9IPT97fsRiiFhe2Q=="
   "resolved" "https://registry.npmjs.org/@sanity/ui/-/ui-0.37.9.tgz"
   "version" "0.37.9"
@@ -1997,7 +1997,7 @@
     "react-popper" "^2.2.5"
     "react-refractor" "^2.1.7"
 
-"@sanity/util@2.30.5":
+"@sanity/util@>= 2.5.0", "@sanity/util@2.30.5":
   "integrity" "sha512-2KIArSNKsnA8A4U52jpaswMvKVRPaq8a9bQBF3uanbEeh/fuadegVgmRzYEgC07sGSDfP4jD3PfzrLnRXQrlfg=="
   "resolved" "https://registry.npmjs.org/@sanity/util/-/util-2.30.5.tgz"
   "version" "2.30.5"
@@ -10649,7 +10649,7 @@
   dependencies:
     "debounce" "^1.2.1"
 
-"react@*", "react@^0.14.0 || ^15.0.0 || ^16.0.0 || ^17.0.0", "react@^15.0.0 || ^16.0.0 || ^17.0.0 ", "react@^15.3.0 || ^16.0.0 || ^17.0.0", "react@^15.3.0 || 16 || 17 || 18", "react@^16.0.0 || ^17.0.0", "react@^16.11.0 || ^17.0.0 || ^18.0.0", "react@^16.14.0", "react@^16.2.0 || ^17", "react@^16.8.0 || ^17.0.0", "react@^16.8.0 || ^17.0.0 || ^18.0.0", "react@^16.8.0 || 17.x", "react@^16.9 || ^17", "react@^16.9 || ^17 || ^18", "react@^17 || ^18", "react@^17.0.0 || ^18.0.0", "react@^17.0.2", "react@>= 16.8.0", "react@>=15", "react@>=15.0.0", "react@>=16.13", "react@>=16.4.2", "react@>=16.8 || ^17.0.0", "react@>=16.8 || ^17.0.0 || ^18.0.0", "react@>=16.8.0", "react@0.14 || 15 || 16 || 17 || 18":
+"react@*", "react@^0.14.0 || ^15.0.0 || ^16.0.0 || ^17.0.0", "react@^15.0.0 || ^16.0.0 || ^17.0.0 ", "react@^15.3.0 || ^16.0.0 || ^17.0.0", "react@^15.3.0 || 16 || 17 || 18", "react@^16.0.0 || ^17.0.0", "react@^16.11.0 || ^17.0.0 || ^18.0.0", "react@^16.14.0", "react@^16.2.0 || ^17", "react@^16.8.0 || ^17.0.0", "react@^16.8.0 || ^17.0.0 || ^18.0.0", "react@^16.8.0 || 17.x", "react@^16.9 || ^17", "react@^16.9 || ^17 || ^18", "react@^17 || ^18", "react@^17.0.0", "react@^17.0.0 || ^18.0.0", "react@^17.0.2", "react@>= 16.8.0", "react@>=15", "react@>=15.0.0", "react@>=16.13", "react@>=16.4.2", "react@>=16.8 || ^17.0.0", "react@>=16.8 || ^17.0.0 || ^18.0.0", "react@>=16.8.0", "react@0.14 || 15 || 16 || 17 || 18":
   "integrity" "sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA=="
   "resolved" "https://registry.npmjs.org/react/-/react-17.0.2.tgz"
   "version" "17.0.2"
@@ -11324,6 +11324,16 @@
   dependencies:
     "diff-match-patch" "^1.0.5"
 
+"sanity-plugin-prefixed-slug@^1.0.1":
+  "integrity" "sha512-u3RdktLyJd5NoIaPd1IBqfH33a/W+s8WvpuQ4QlQQo5MHxnQTwBkeA2tM+PadWG0idAeq08BqqbaZrhIuTk0Fg=="
+  "resolved" "https://registry.npmjs.org/sanity-plugin-prefixed-slug/-/sanity-plugin-prefixed-slug-1.0.1.tgz"
+  "version" "1.0.1"
+  dependencies:
+    "@sanity/base" ">= 2.5.0"
+    "@sanity/ui" ">= 0.33.9"
+    "@sanity/util" ">= 2.5.0"
+    "speakingurl" "^14.0.1"
+
 "sax@~1.2.4":
   "integrity" "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
   "resolved" "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz"
@@ -11792,6 +11802,11 @@
   "resolved" "https://registry.npmjs.org/speakingurl/-/speakingurl-13.0.0.tgz"
   "version" "13.0.0"
 
+"speakingurl@^14.0.1":
+  "integrity" "sha512-1POYv7uv2gXoyGFpBCmpDVSNV74IfsWlDW216UPjbWufNf+bSU6GdbDsxdcxtfwb4xlI3yxzOTKClUosxARYrQ=="
+  "resolved" "https://registry.npmjs.org/speakingurl/-/speakingurl-14.0.1.tgz"
+  "version" "14.0.1"
+
 "speedometer@~1.0.0":
   "integrity" "sha512-lgxErLl/7A5+vgIIXsh9MbeukOaCb2axgQ+bKCdIE+ibNT4XNYGNCR1qFEGq6F+YDASXK3Fh/c5FgtZchFolxw=="
   "resolved" "https://registry.npmjs.org/speedometer/-/speedometer-1.0.0.tgz"
@@ -12086,7 +12101,7 @@
     "hey-listen" "^1.0.8"
     "tslib" "^2.1.0"
 
-"styled-components@^5.0.0", "styled-components@^5.2", "styled-components@^5.2.0", "styled-components@^5.3.5":
+"styled-components@^5.0.0", "styled-components@^5.2", "styled-components@^5.2.0", "styled-components@^5.3.5", "styled-components@>= 5.0.0":
   "integrity" "sha512-ndETJ9RKaaL6q41B69WudeqLzOpY1A/ET/glXkNZ2T7dPjPqpPCXXQjDFYZWwNnE5co0wX+gTCqx9mfxTmSIPg=="
   "resolved" "https://registry.npmjs.org/styled-components/-/styled-components-5.3.5.tgz"
   "version" "5.3.5"


### PR DESCRIPTION
- Slugs for innholdsseksjoner på produktsiden for dagpenger som brukes for å navigere seg direkte til en seksjon. Brukes også i innholdsmenyen.

<img width="647" alt="Skjermbilde 2022-08-30 kl  14 31 53" src="https://user-images.githubusercontent.com/10635523/187437348-df6e5158-a348-4c15-aca1-3486306d7c3a.png">

- Filtrerer innholdsseksjonreferanser på språk slik at man kun kan velge innholdsseksjoner på samme språk som oppsettet
