### PR TITLE
Legger til Accordion/Readmore schemas for Produktsiden til innholdssp…

### DIFF
--- a/schemas/produktside/produktside-component-schemas/produktsideAccordion.tsx
+++ b/schemas/produktside/produktside-component-schemas/produktsideAccordion.tsx
@@ -1,0 +1,31 @@
+export const produktsideAccordion = {
+  name: "produktsideAccordion",
+  title: "Accordion",
+  type: "object",
+  fields: [
+    {
+      title: "Tittel",
+      name: "title",
+      type: "string",
+      validation: (Rule) => Rule.required().error("Tittel er påkrevd."),
+    },
+    {
+      title: "Innhold",
+      name: "content",
+      type: "text",
+      validation: (Rule) => Rule.required().error("Innhold er påkrevd."),
+    },
+  ],
+  preview: {
+    select: {
+      title: "title",
+      subtitle: "content",
+    },
+    prepare({ title, subtitle }) {
+      return {
+        title: `(Accordion) ${title}`,
+        subtitle,
+      };
+    },
+  },
+};

--- a/schemas/produktside/produktside-component-schemas/produktsideReadMore.tsx
+++ b/schemas/produktside/produktside-component-schemas/produktsideReadMore.tsx
@@ -1,0 +1,43 @@
+export const produktsideReadMore = {
+  name: "produktsideReadMore",
+  title: "ReadMore",
+  type: "object",
+  fields: [
+    {
+      title: "Tittel",
+      name: "title",
+      type: "string",
+      validation: (Rule) => Rule.required().error("Tittel er påkrevd."),
+    },
+    {
+      title: "Innhold",
+      name: "content",
+      type: "text",
+      validation: (Rule) => Rule.required().error("Innhold er påkrevd."),
+    },
+    {
+      title: "Størrelse",
+      name: "size",
+      type: "string",
+      initialValue: "medium",
+      options: {
+        list: [
+          { title: "Små", value: "small" },
+          { title: "Medium", value: "medium" },
+        ],
+      },
+    },
+  ],
+  preview: {
+    select: {
+      title: "title",
+      subtitle: "content",
+    },
+    prepare({ title, subtitle }) {
+      return {
+        title: `(ReadMore) ${title}`,
+        subtitle,
+      };
+    },
+  },
+};

--- a/schemas/produktside/produktsideSection/produktsideSectionRichText.ts
+++ b/schemas/produktside/produktsideSection/produktsideSectionRichText.ts
@@ -1,5 +1,7 @@
 import { produktsideSectionReferenceName } from "./produktsideSectionReference";
 import { GtoNOKDecorator } from "../produktside-decorators/produktside-decorators";
+import { produktsideAccordion } from "../produktside-component-schemas/produktsideAccordion";
+import { produktsideReadMore } from "../produktside-component-schemas/produktsideReadMore";
 
 export const produktsideSectionRichText = {
   title: "Innholdsseksjon Rich Text",
@@ -14,5 +16,7 @@ export const produktsideSectionRichText = {
     },
     { type: "customComponent" },
     { type: produktsideSectionReferenceName },
+    { type: produktsideAccordion.name },
+    { type: produktsideReadMore.name },
   ],
 };

--- a/schemas/produktside/schema.ts
+++ b/schemas/produktside/schema.ts
@@ -1,3 +1,5 @@
+import { produktsideAccordion } from "./produktside-component-schemas/produktsideAccordion";
+import { produktsideReadMore } from "./produktside-component-schemas/produktsideReadMore";
 import { produktsideKortFortalt } from "./produktsideKortFortalt";
 import { produktsideRichText } from "./produktsideRichText";
 import { produktsideSection } from "./produktsideSection/produktsideSection";
@@ -6,7 +8,10 @@ import { produktsideSectionRichText } from "./produktsideSection/produktsideSect
 import { produktsideSettings } from "./produktsideSettings";
 import { produktsideText } from "./produktsideText";
 
+const componentSchemas = [produktsideAccordion, produktsideReadMore];
+
 export const produktsideSchemas = [
+  ...componentSchemas,
   produktsideKortFortalt,
   produktsideRichText,
   produktsideSection,
@@ -15,7 +20,10 @@ export const produktsideSchemas = [
   produktsideSettings,
   produktsideText,
 ];
+
 export {
+  produktsideAccordion,
+  produktsideReadMore,
   produktsideKortFortalt,
   produktsideRichText,
   produktsideSection,


### PR DESCRIPTION
…rint

- Midlertidige komponent-schemas som skal brukes til innholdssprinten i Produktsiden

Relatert PR: https://github.com/navikt/dp-produktside-frontend/pull/43